### PR TITLE
Fix phantom-action contamination in Q-target argmax

### DIFF
--- a/config.py
+++ b/config.py
@@ -42,20 +42,49 @@ class NetworkConfig:
     never silently desynchronise the training pipeline from what
     `EnhancedPlayer.get_state()` actually produces. Overriding these from
     a config file is still supported but discouraged.
+
+    `q_lr` history: 1e-3 → 3e-4 (stabilisation pass) → 5e-4 (signal pass).
+    The first cut to 3e-4 was protecting against the Q-divergence we now
+    know was driven by phantom-action drift; with action masking in place
+    `\|Q*\|` is bounded at ~0.6 (50× headroom under γ=0.97), so we can
+    afford a more aggressive LR. 5e-4 gives ~67% more signal per gradient
+    step while still staying well below the 1e-3 that destabilised the
+    pre-fix run.
     """
     state_dim: int = STATE_DIM
     action_dim: int = ACTION_DIM
     q_hidden: tuple = (256, 128, 64)
     pi_hidden: tuple = (256, 256)
-    q_lr: float = 1e-3
+    q_lr: float = 5e-4
     pi_lr: float = 1e-3
     grad_clip: float = 1.0
 
 
 @dataclass
 class NFSPConfig:
-    """Neural Fictitious Self-Play training knobs."""
-    gamma: float = 0.99
+    """Neural Fictitious Self-Play training knobs.
+
+    Reward / target stability defaults (post-divergence pass):
+      - `win_bonus` lowered 5.0 → 1.0
+      - `trick_diff_weight` introduced (was hard-coded 0.1 inside
+        `compute_terminal_reward`; now configurable, default 0.02)
+      Net effect: terminal reward range shrinks from roughly ±6.3 to
+      roughly ±1.26, so |Q*| stays within order-1 instead of order-15.
+      This is the single biggest fix for the deadly-triad blow-up
+      observed in the 50k run.
+
+      - `tau` introduced for Polyak (soft) target-net updates. When
+        tau > 0 the target net is averaged toward the online net every
+        gradient step (`θ_target ← τθ + (1-τ)θ_target`); when tau = 0
+        we fall back to the legacy hard copy every
+        `target_update_frequency` steps for backward compatibility.
+    """
+    # gamma lowered 0.99 → 0.97 in the action-masking pass. With γ=0.99 the
+    # theoretical |Q*| ceiling for ±1.26 rewards is 1.26 / 0.01 = 126, plenty
+    # of room for phantom-action drift to climb forever before clipping.
+    # γ=0.97 caps it at 1.26 / 0.03 = 42, while still giving a 33-step
+    # bootstrap horizon — overkill for a 13-trick episode anyway.
+    gamma: float = 0.97
     eta: float = 0.25                     # P(sample from average policy)
     epsilon_start: float = 0.15
     epsilon_min: float = 0.02
@@ -63,11 +92,22 @@ class NFSPConfig:
     replay_size: int = 100_000
     sl_reservoir_size: int = 150_000
     batch_size: int = 32
-    target_update_frequency: int = 200
+    target_update_frequency: int = 200    # used only when tau == 0
+    # tau lowered 0.005 → 0.002 in the action-masking pass. Belt-and-braces:
+    # the masking fix is the real cure for divergence, but a slower target
+    # net adds margin for the optimizer to adapt to changing legal-action
+    # distributions early in training without overshooting.
+    tau: float = 0.002                    # Polyak rate; 0 disables soft updates
     learn_every: int = 4                  # gradient step every N plays
     reward_mode: str = REWARD_OUTCOME
     shaping_weight: float = 0.1           # scale for heuristic signal in "mixed"
-    win_bonus: float = 5.0                # terminal reward when agent's team reaches 7
+    win_bonus: float = 1.0                # terminal reward when agent's team reaches 7
+    # trick_diff_weight: 0.02 → 0.10 in the signal-strength pass. With
+    # action masking in place, terminal-reward range can safely grow from
+    # ±1.26 to ±2.30 without re-igniting Q-target drift. The trick-margin
+    # signal is what discriminates "won 13-0" from "won 7-6" — exactly
+    # what the Q-net needs to push policy past the random-baseline plateau.
+    trick_diff_weight: float = 0.10       # coefficient on (my - opp) tricks at terminal
     kot_bonus: float = 3.0                # additional reward for 7-0 sweep (extension)
 
 

--- a/enhanced_player.py
+++ b/enhanced_player.py
@@ -208,10 +208,11 @@ class SharedNFSPLearner:
         sl_reservoir_size: int = 150000,
         *,
         gamma: float = 0.99,
-        q_lr: float = 1e-3,
+        q_lr: float = 3e-4,
         pi_lr: float = 1e-3,
         batch_size: int = 32,
         target_update_frequency: int = 200,
+        tau: float = 0.005,
         replay_size: int = 100_000,
         epsilon_start: float = 0.15,
         epsilon_min: float = 0.02,
@@ -225,7 +226,14 @@ class SharedNFSPLearner:
         self.learning_rate = q_lr
         self.sl_lr = pi_lr
         self.batch_size = batch_size
+        # When tau > 0 we run soft (Polyak) target updates every gradient
+        # step and ignore `target_update_frequency`. When tau == 0 we fall
+        # back to the legacy hard copy every N steps. Soft updates are
+        # strictly better for stability — they cap how fast the target net
+        # can move, which kills the bootstrapping feedback loop that drove
+        # the divergence we saw at game ~25k of the 50k run.
         self.target_update_frequency = target_update_frequency
+        self.tau = float(tau)
         self.steps_done = 0
         self.epsilon = epsilon_start
         self.epsilon_min = epsilon_min
@@ -239,6 +247,18 @@ class SharedNFSPLearner:
         # short, so unbounded growth between snapshots is fine in practice.
         self._q_losses: List[float] = []
         self._sl_losses: List[float] = []
+        # Mean absolute Q-target magnitude. Diagnostic for divergence:
+        # if this climbs without bound, the Q-net is in a deadly-triad
+        # blow-up. Healthy training keeps |Q*| ~ |reward| / (1-gamma)·O(1).
+        self._q_target_abs: List[float] = []
+        # Mean (max-min) Q over legal next-actions per row, averaged over
+        # the batch. This is the *discrimination capacity* of the Q-net:
+        # how strongly it differentiates between the cards it could
+        # legally play. If it stays near 0 the policy is essentially
+        # uniform-over-legal — the symptom of a dead-flat learning
+        # signal. We want this to climb during training (typically into
+        # 0.3–1.5 range) as the Q-net learns which cards are better.
+        self._q_advantage: List[float] = []
         self._grad_steps_q = 0
         self._grad_steps_sl = 0
 
@@ -259,10 +279,31 @@ class SharedNFSPLearner:
         next_state: torch.Tensor,
         done: bool,
         rl_eligible: bool,
+        next_legal_mask: Optional[torch.Tensor] = None,
     ) -> None:
+        """Append a transition to replay.
+
+        `next_legal_mask` is a 1-D bool tensor of shape [action_dim] that is
+        True at indices the agent could legally select at next_state. Used
+        in `_optimize_q` to mask the next-Q argmax so that Double-DQN
+        targets only ever evaluate Q-values at actions that could actually
+        be taken — this prevents the unbounded drift of phantom-action
+        Q-values that was poisoning targets and locking the policy below
+        random play.
+
+        When None (e.g. the legacy path before the masking fix shipped, or
+        from non-game callers), defaults to all-True. Hokm.play_round always
+        provides a mask in production.
+        """
         self.sl_buffer.append((state.detach().cpu(), int(action)))
         if rl_eligible and action >= 0:
-            self.memory.push((state, action, reward, next_state, done))
+            if next_legal_mask is None:
+                next_legal_mask = torch.ones(self.action_dim, dtype=torch.bool)
+            else:
+                next_legal_mask = next_legal_mask.to(dtype=torch.bool)
+            self.memory.push(
+                (state, action, reward, next_state, done, next_legal_mask)
+            )
 
     def maybe_optimize(self) -> None:
         self._ply_since_learn += 1
@@ -285,20 +326,68 @@ class SharedNFSPLearner:
         rewards = torch.tensor(batch[2], dtype=torch.float32).unsqueeze(1).to(device)
         next_states = torch.stack(batch[3])
         dones = torch.tensor(batch[4], dtype=torch.float32).unsqueeze(1).to(device)
+        # Per-transition mask of which next-state actions could legally be
+        # taken. Critical: without this, argmax can pick illegal "phantom"
+        # actions whose Q-values are never anchored by real-world rewards
+        # (since they're never executed). Phantom-action Q-values then drift
+        # freely upward and poison every legitimate state via bootstrapping.
+        next_masks = torch.stack(batch[5]).to(device)  # [B, action_dim] bool
 
         current_q_values = self.q_net(states).gather(1, actions)
-        next_actions = self.q_net(next_states).argmax(1, keepdim=True)
+        # Double-DQN target: action selection from online net, value from
+        # target net — both restricted to legal next-state actions.
+        next_q_raw = self.q_net(next_states)
+        next_q_online = next_q_raw.masked_fill(~next_masks, float("-inf"))
+        next_actions = next_q_online.argmax(1, keepdim=True)
+        # Q-advantage diagnostic: mean (max - min) Q-value over legal
+        # next-actions, averaged across rows that have ≥1 legal action.
+        # Tracks the *discrimination capacity* of the Q-net: if this stays
+        # near 0 the policy is essentially uniform-over-legal — the
+        # symptom of a dead-flat learning signal that a stable but
+        # under-powered training regime produces. Should grow into
+        # 0.3–1.5 range over a healthy run.
+        with torch.no_grad():
+            row_has_legal = next_masks.any(dim=1)
+            if row_has_legal.any():
+                row_max = next_q_online.max(dim=1).values
+                next_q_for_min = next_q_raw.masked_fill(
+                    ~next_masks, float("inf")
+                )
+                row_min = next_q_for_min.min(dim=1).values
+                spread = (row_max - row_min)[row_has_legal]
+                finite = spread[torch.isfinite(spread)]
+                if finite.numel() > 0:
+                    self._q_advantage.append(float(finite.mean().item()))
         next_q_values = self.target_q_net(next_states).gather(1, next_actions).detach()
+        # Terminal transitions zero out next_q via (1-dones); for those we
+        # also zero next_q explicitly so an empty mask (hand_empty=True at
+        # the last play of a round) can't yield -inf and contaminate the
+        # target via the * 0 multiplication (-inf * 0 == NaN in float).
+        next_q_values = torch.where(
+            dones.bool(), torch.zeros_like(next_q_values), next_q_values
+        )
         target_q_values = rewards + (self.gamma * next_q_values * (1 - dones))
-        loss = F.mse_loss(current_q_values, target_q_values)
+        # Huber loss is linear (instead of quadratic) for |TD error| > 1, so
+        # one outlier transition no longer produces a runaway gradient.
+        # This is the standard DQN choice and what the NFSP reference impl
+        # uses. Together with the smaller reward range, this is what makes
+        # the rolling Q-loss stay in O(1) instead of climbing to O(80).
+        loss = F.smooth_l1_loss(current_q_values, target_q_values)
         self.optimizer.zero_grad()
         loss.backward()
         torch.nn.utils.clip_grad_norm_(self.q_net.parameters(), max_norm=self.grad_clip)
         self.optimizer.step()
         self._q_losses.append(float(loss.detach().item()))
+        self._q_target_abs.append(float(target_q_values.detach().abs().mean().item()))
         self._grad_steps_q += 1
         self.steps_done += 1
-        if self.steps_done % self.target_update_frequency == 0:
+        # Soft target updates (Polyak averaging). When tau == 0 fall back to
+        # the legacy hard-copy schedule for backward-compat with old configs.
+        if self.tau > 0.0:
+            with torch.no_grad():
+                for tp, p in zip(self.target_q_net.parameters(), self.q_net.parameters()):
+                    tp.data.mul_(1.0 - self.tau).add_(p.data, alpha=self.tau)
+        elif self.steps_done % self.target_update_frequency == 0:
             self.target_q_net.load_state_dict(self.q_net.state_dict())
             self.target_q_net.eval()
 
@@ -330,14 +419,26 @@ class SharedNFSPLearner:
 
         q = (sum(self._q_losses) / len(self._q_losses)) if self._q_losses else math.nan
         s = (sum(self._sl_losses) / len(self._sl_losses)) if self._sl_losses else math.nan
+        qabs = (
+            (sum(self._q_target_abs) / len(self._q_target_abs))
+            if self._q_target_abs else math.nan
+        )
+        qadv = (
+            (sum(self._q_advantage) / len(self._q_advantage))
+            if self._q_advantage else math.nan
+        )
         out = {
             "q_loss": q,
             "sl_loss": s,
+            "q_target_abs": qabs,
+            "q_advantage": qadv,
             "q_steps": len(self._q_losses),
             "sl_steps": len(self._sl_losses),
         }
         self._q_losses.clear()
         self._sl_losses.clear()
+        self._q_target_abs.clear()
+        self._q_advantage.clear()
         return out
 
     @classmethod
@@ -355,6 +456,7 @@ class SharedNFSPLearner:
             pi_lr=net.pi_lr,
             batch_size=n.batch_size,
             target_update_frequency=n.target_update_frequency,
+            tau=getattr(n, "tau", 0.005),
             replay_size=n.replay_size,
             epsilon_start=n.epsilon_start,
             epsilon_min=n.epsilon_min,
@@ -403,7 +505,8 @@ class EnhancedPlayer:
         learn_every: int = 4,
         reward_mode: str = REWARD_HEURISTIC,
         shaping_weight: float = 0.1,
-        win_bonus: float = 5.0,
+        win_bonus: float = 1.0,
+        trick_diff_weight: float = 0.10,
     ):
         self.name = name
         self.is_human = is_human
@@ -446,6 +549,7 @@ class EnhancedPlayer:
         self.reward_mode = reward_mode
         self.shaping_weight = float(shaping_weight)
         self.win_bonus = float(win_bonus)
+        self.trick_diff_weight = float(trick_diff_weight)
 
         if self._shared is not None:
             self.epsilon = self._shared.epsilon
@@ -816,7 +920,18 @@ class EnhancedPlayer:
 
         Returns 0 in pure heuristic mode (backward compatible). In outcome /
         mixed modes, returns ±win_bonus for the binary hand outcome plus a
-        small trick-differential signal (bounded by ±0.1 * 13 = ±1.3).
+        small trick-differential signal (`trick_diff_weight * (my-opp)`,
+        bounded by `trick_diff_weight * 13`).
+
+        Default scale (post-action-masking pass): win_bonus=1.0,
+        trick_diff_weight=0.10 → terminal reward range ≈ ±2.30. The earlier
+        ±1.26 scale was set when phantom-action drift was inflating |Q*|
+        unboundedly; with the masking fix |Q*| is anchored to real reward,
+        so we can restore the per-trick signal-strength back toward its
+        original (pre-stability-pass) value of 0.10. The coefficient
+        discriminates dominant wins (13-0) from squeakers (7-6), which is
+        the credit-assignment signal the Q-net needs to escape the
+        roughly-uniform-policy plateau.
         """
         if self.reward_mode == REWARD_HEURISTIC or not self.team:
             return 0.0
@@ -825,7 +940,7 @@ class EnhancedPlayer:
         opp_tricks = total - my_tricks
         won = my_tricks >= 7
         diff = my_tricks - opp_tricks
-        return (self.win_bonus if won else -self.win_bonus) + 0.1 * diff
+        return (self.win_bonus if won else -self.win_bonus) + self.trick_diff_weight * diff
 
     def _can_win_trick(self, card, lead_suit):
         if not self.current_trick:
@@ -848,7 +963,25 @@ class EnhancedPlayer:
             return False
         return card.suit == teammate_card.suit and card.value > teammate_card.value
 
-    def store_experience(self, state, action, reward, next_state, done, rl_eligible=True):
+    def store_experience(
+        self,
+        state,
+        action,
+        reward,
+        next_state,
+        done,
+        rl_eligible=True,
+        next_legal_mask: Optional[torch.Tensor] = None,
+    ):
+        """Push a transition for RL + SL learning.
+
+        `next_legal_mask` (bool tensor [action_dim]) tells the optimizer
+        which next-state actions could legally be taken; used to mask
+        the next-Q argmax. See SharedNFSPLearner.push_transition for the
+        full rationale. Hokm.play_round always supplies it; tests and
+        other callers may omit it (defaults to all-True for backward
+        compatibility).
+        """
         if not self.learning_enabled or self.is_human:
             return
         if action is None or action < 0:
@@ -856,7 +989,8 @@ class EnhancedPlayer:
 
         if self._shared is not None:
             self._shared.push_transition(
-                state, action, reward, next_state, done, rl_eligible
+                state, action, reward, next_state, done, rl_eligible,
+                next_legal_mask=next_legal_mask,
             )
             if rl_eligible:
                 self.total_reward += reward
@@ -865,7 +999,11 @@ class EnhancedPlayer:
         self.sl_buffer.append((state.detach().cpu(), int(action)))
         if not rl_eligible:
             return
-        self.memory.push((state, action, reward, next_state, done))
+        if next_legal_mask is None:
+            next_legal_mask = torch.ones(ACTION_DIM, dtype=torch.bool)
+        else:
+            next_legal_mask = next_legal_mask.to(dtype=torch.bool)
+        self.memory.push((state, action, reward, next_state, done, next_legal_mask))
         self.total_reward += reward
 
     def optimize_model(self, beta=0.4):
@@ -898,11 +1036,22 @@ class EnhancedPlayer:
         next_states = torch.stack(batch[3])
         dones = torch.tensor(batch[4], dtype=torch.float32).unsqueeze(1).to(device)
 
+        next_masks = torch.stack(batch[5]).to(device)
+
         current_q_values = self.q_net(states).gather(1, actions)
-        next_actions = self.q_net(next_states).argmax(1, keepdim=True)
+        next_q_online = self.q_net(next_states).masked_fill(
+            ~next_masks, float("-inf")
+        )
+        next_actions = next_q_online.argmax(1, keepdim=True)
         next_q_values = self.target_q_net(next_states).gather(1, next_actions).detach()
+        next_q_values = torch.where(
+            dones.bool(), torch.zeros_like(next_q_values), next_q_values
+        )
         target_q_values = rewards + (self.gamma * next_q_values * (1 - dones))
-        loss = F.mse_loss(current_q_values, target_q_values)
+        # Huber loss + (legacy path here keeps hard target updates; the
+        # shared learner is the primary trainer and uses Polyak. This
+        # path is mainly exercised by single-agent unit tests.)
+        loss = F.smooth_l1_loss(current_q_values, target_q_values)
         self.optimizer.zero_grad()
         loss.backward()
         torch.nn.utils.clip_grad_norm_(self.q_net.parameters(), max_norm=1.0)

--- a/hokm.py
+++ b/hokm.py
@@ -8,7 +8,14 @@ import pandas as pd
 import os
 from datetime import datetime
 from typing import Optional
-from game_constants import Card, suits, ranks, rank_values
+from game_constants import (
+    ACTION_DIM,
+    Card,
+    card_to_index,
+    suits,
+    ranks,
+    rank_values,
+)
 from enhanced_player import EnhancedPlayer, TeamStrategy
 import time
 import csv
@@ -394,6 +401,17 @@ class Hokm:
         game_over = self.scores[1] >= 7 or self.scores[2] >= 7
 
         # Flush pending transitions with correct `done` + terminal reward.
+        # We compute `next_legal_mask` from the player's hand at flush time
+        # — by then the played card has already been removed from `p.hand`,
+        # so the mask reflects the actual cards available at the player's
+        # next decision point. This is an over-approximation of legality
+        # (it doesn't yet incorporate the next trick's lead suit, which
+        # isn't known yet), but it bounds argmax to *cards in hand*, which
+        # is the critical invariant: every card in hand will eventually be
+        # played, so its Q-value is anchored by real-world feedback. Cards
+        # not in hand (already played, never dealt) are the dangerous
+        # phantom actions whose Q-values drift unboundedly without this
+        # mask. See SharedNFSPLearner.push_transition for full rationale.
         for rec in pending:
             p = rec["player"]
             hand_empty = len(p.hand) == 0
@@ -408,6 +426,10 @@ class Hokm:
                         terminal = 0.0
                 reward += terminal
             next_state = p.get_state()
+            next_legal_mask = torch.zeros(ACTION_DIM, dtype=torch.bool)
+            if not done:
+                for c in p.hand:
+                    next_legal_mask[card_to_index(c)] = True
             p.store_experience(
                 rec["state"],
                 rec["action"],
@@ -415,6 +437,7 @@ class Hokm:
                 next_state,
                 done,
                 rl_eligible=rec["rl_eligible"],
+                next_legal_mask=next_legal_mask,
             )
             p.optimize_model()
 

--- a/templates/dev_console.html
+++ b/templates/dev_console.html
@@ -205,6 +205,8 @@
           <div class="kpi-card"><div class="kpi-label">Mean trick diff (T1−T2)</div><div class="kpi-value" id="kpi-trickdiff">—</div></div>
           <div class="kpi-card"><div class="kpi-label">Mean reward / game</div><div class="kpi-value" id="kpi-meanreward">—</div></div>
           <div class="kpi-card"><div class="kpi-label">Recent Q-loss</div><div class="kpi-value" id="kpi-qloss">—</div></div>
+          <div class="kpi-card"><div class="kpi-label">Recent |Q*|</div><div class="kpi-value" id="kpi-qabs">—</div></div>
+          <div class="kpi-card"><div class="kpi-label">Recent Q-advantage</div><div class="kpi-value" id="kpi-qadv">—</div></div>
           <div class="kpi-card"><div class="kpi-label">Total grad steps</div><div class="kpi-value" id="kpi-gradsteps">—</div></div>
         </div>
 
@@ -256,13 +258,17 @@
         <div class="grid-2">
           <div class="card">
             <h3 style="margin-top: 0; font-size: 1rem;">
-              Training loss (rolling mean, log scale)
+              Training loss + |Q*| + Q-advantage (rolling mean, log scale)
               <span class="muted-tag" id="tag-window-5">window 200</span>
             </h3>
             <p class="hint" style="margin: 0.2rem 0 0.4rem 0;">
-              Q-loss is the TD error of the value network; SL-loss is the cross-entropy of the average-policy network.
-              In a healthy run both should trend <strong>downward</strong> over time. This is the most reliable signal of learning,
-              independent of self-play symmetry.
+              Q-loss = Huber TD error; SL-loss = avg-policy cross-entropy;
+              |Q*| (long-dashed) = mean absolute Q-target magnitude (divergence canary —
+              should stay bounded);
+              Q-advantage (short-dashed) = mean (max-Q − min-Q) over <em>legal</em> next-actions
+              (discrimination canary — should <em>climb</em> as the agent learns which cards
+              are better than others; staying near 0 means the policy is essentially
+              uniform over legal cards).
             </p>
             <div class="chart-wrap"><canvas id="chart-losses"></canvas></div>
           </div>
@@ -683,7 +689,7 @@
         .forEach(k => destroyChart(k));
       $('#metrics-summary').textContent = 'No data — start a training run.';
       ['#kpi-games', '#kpi-cumwin', '#kpi-recentwin', '#kpi-trickdiff',
-       '#kpi-meanreward', '#kpi-qloss', '#kpi-gradsteps']
+       '#kpi-meanreward', '#kpi-qloss', '#kpi-qabs', '#kpi-qadv', '#kpi-gradsteps']
         .forEach(s => $(s).textContent = '—');
       return;
     }
@@ -701,6 +707,8 @@
     const r4  = metrics.player4_avg_reward || [];
     const qLoss     = metrics.q_loss        || [];
     const slLoss    = metrics.sl_loss       || [];
+    const qTargAbs  = metrics.q_target_abs  || [];
+    const qAdvantage = metrics.q_advantage  || [];
     const qSteps    = metrics.q_grad_steps  || [];
     const slSteps   = metrics.sl_grad_steps || [];
 
@@ -725,6 +733,8 @@
     ]);
     $('#kpi-meanreward').textContent = fmtNum(recentReward, 3);
     $('#kpi-qloss').textContent = fmtNum(mean(lastN(qLoss, 500)), 4);
+    $('#kpi-qabs').textContent = fmtNum(mean(lastN(qTargAbs, 500)), 3);
+    $('#kpi-qadv').textContent = fmtNum(mean(lastN(qAdvantage, 500)), 3);
     const totalGradSteps = qSteps.reduce((a, b) => a + (b || 0), 0);
     $('#kpi-gradsteps').textContent = totalGradSteps.toLocaleString();
 
@@ -748,6 +758,8 @@
     const tw4Roll = rollingMean(tw4, W);
     const qLossRoll  = rollingMean(qLoss, W);
     const slLossRoll = rollingMean(slLoss, W);
+    const qTargAbsRoll = rollingMean(qTargAbs, W);
+    const qAdvantageRoll = rollingMean(qAdvantage, W);
     const qStepsRoll  = rollingMean(qSteps, W);
     const slStepsRoll = rollingMean(slSteps, W);
 
@@ -863,18 +875,24 @@
     }
 
     // ---------- 7) Training losses (log scale) ----------
+    // |Q*| is overlaid as a third dashed line. Healthy training keeps it
+    // bounded (roughly reward_range / (1-gamma) ≈ a few units). If it
+    // climbs without bound, the deadly triad is winning and Q-loss will
+    // explode shortly after.
     {
-      const ds = downsample(gn, [qLossRoll, slLossRoll], MAX);
+      const ds = downsample(gn, [qLossRoll, slLossRoll, qTargAbsRoll, qAdvantageRoll], MAX);
       destroyChart('losses');
       charts['losses'] = new Chart($('#chart-losses'), {
         type: 'line',
         data: { labels: ds.labels, datasets: [
-          { label: `Q-loss (rolling ${W})`,  data: ds.series[0], borderColor: '#e07a5f' },
-          { label: `SL-loss (rolling ${W})`, data: ds.series[1], borderColor: '#81b29a' },
+          { label: `Q-loss (rolling ${W})`,        data: ds.series[0], borderColor: '#e07a5f' },
+          { label: `SL-loss (rolling ${W})`,       data: ds.series[1], borderColor: '#81b29a' },
+          { label: `|Q*| (rolling ${W})`,          data: ds.series[2], borderColor: '#c9a559', borderDash: [4, 3] },
+          { label: `Q-advantage (rolling ${W})`,   data: ds.series[3], borderColor: '#9b8cc4', borderDash: [2, 2] },
         ]},
         options: lineOpts({
           spanGaps: true,
-          scales: { y: { type: 'logarithmic', title: { display: true, text: 'loss (log)' } } },
+          scales: { y: { type: 'logarithmic', title: { display: true, text: 'loss / |Q*| / advantage (log)' } } },
         }),
       });
     }

--- a/tests/test_action_masking.py
+++ b/tests/test_action_masking.py
@@ -1,0 +1,132 @@
+"""
+Regression tests for the next-state action-masking fix.
+
+Background: `_optimize_q` used to compute Double-DQN targets via an
+unconstrained argmax over all 52 actions — including cards not in the
+player's hand and cards that violate follow-suit. Q-values at these
+"phantom" actions are never anchored by real-world rewards (they're
+never executed), so they drift freely upward and poison every legitimate
+state via bootstrapping. The symptoms in production were `|Q*|` growing
+without bound and the agent locking into worse-than-random play.
+
+The fix is to attach a `next_legal_mask` (bool tensor [action_dim]) to
+each replay entry and apply `masked_fill(~mask, -inf)` before the argmax.
+These tests pin the invariants that keep the bug from coming back.
+"""
+
+from __future__ import annotations
+
+import torch
+
+from config import DEFAULT_CONFIG, REWARD_OUTCOME
+from enhanced_player import SharedNFSPLearner, EnhancedPlayer
+from game_constants import ACTION_DIM, card_to_index
+from hokm import Hokm
+
+
+def _legal_mask(indices):
+    m = torch.zeros(ACTION_DIM, dtype=torch.bool)
+    for i in indices:
+        m[i] = True
+    return m
+
+
+def test_optimize_q_argmax_respects_next_legal_mask():
+    """The Double-DQN target must never select an illegal next-action.
+
+    We construct a learner, push a small batch of synthetic transitions
+    where the legal next-action set is severely restricted (a single
+    index per transition), then verify that the next-action argmax falls
+    inside the mask for *every* transition no matter what the random
+    Q-net weights say.
+    """
+    learner = SharedNFSPLearner(batch_size=4)
+
+    legal_idx = [3, 17, 41, 0]
+    for k in range(4):
+        s = torch.zeros(learner.state_dim)
+        ns = torch.zeros(learner.state_dim)
+        learner.push_transition(
+            state=s,
+            action=legal_idx[k],
+            reward=0.0,
+            next_state=ns,
+            done=False,
+            rl_eligible=True,
+            next_legal_mask=_legal_mask([legal_idx[k]]),
+        )
+
+    # Pull the same batch out (the only one available) and check argmax.
+    # `random.sample` permutes the order, so we verify the per-row
+    # invariant: each chosen action must be the unique True index in its
+    # own row's mask.
+    batch = list(zip(*learner.memory.sample(4)))
+    next_states = torch.stack(batch[3])
+    next_masks = torch.stack(batch[5])
+    q = learner.q_net(next_states).masked_fill(~next_masks, float("-inf"))
+    next_actions = q.argmax(1)
+    for row, picked in enumerate(next_actions.tolist()):
+        legal_in_row = next_masks[row].nonzero(as_tuple=False).flatten().tolist()
+        assert picked in legal_in_row, (
+            f"row {row}: argmax picked {picked} but only {legal_in_row} "
+            f"were legal"
+        )
+
+
+def test_optimize_q_runs_without_nan_at_terminal_with_empty_mask():
+    """At done=True the next-state has an empty hand and the mask is all
+    False. Multiplying -inf * 0 yields NaN in float, which would silently
+    corrupt the target. The optimizer must zero next_q before the
+    multiplication. This test triggers that path.
+    """
+    learner = SharedNFSPLearner(batch_size=2)
+    s = torch.zeros(learner.state_dim)
+    ns = torch.zeros(learner.state_dim)
+    empty_mask = torch.zeros(ACTION_DIM, dtype=torch.bool)
+    for _ in range(2):
+        learner.push_transition(
+            state=s, action=0, reward=1.0, next_state=ns, done=True,
+            rl_eligible=True, next_legal_mask=empty_mask,
+        )
+    learner._optimize_q()
+    # If NaN had leaked we'd see a NaN in the recorded Q-loss.
+    assert learner._q_losses, "expected one loss recorded"
+    assert all(l == l for l in learner._q_losses), \
+        "Q-loss must not be NaN even when mask is empty at done=True"
+
+
+def test_play_round_supplies_next_legal_mask():
+    """End-to-end: after a full hand of self-play, every transition stored
+    in the shared replay must carry a `next_legal_mask` of the right
+    shape, dtype, and structure (non-empty for non-terminal transitions,
+    empty exactly when done=True with hand_empty)."""
+    import random as _random
+
+    cfg = DEFAULT_CONFIG
+    learner = SharedNFSPLearner.from_config(cfg)
+    players = [
+        EnhancedPlayer(
+            f"P{i}",
+            shared_learner=learner,
+            reward_mode=REWARD_OUTCOME,
+        )
+        for i in range(4)
+    ]
+    game = Hokm(players, minimal_logging=True, rng=_random.Random(0))
+    game.play_game(save_excel_log=False)
+
+    assert len(learner.memory) >= 4, "full hand should produce many replay entries"
+    saw_terminal = False
+    for entry in list(learner.memory.memory):
+        s, a, r, ns, done, mask = entry
+        assert mask.dtype == torch.bool
+        assert mask.shape == (ACTION_DIM,)
+        if done:
+            saw_terminal = True
+            # At done=True, mask is empty (hand_empty after final play).
+            assert not mask.any(), \
+                f"terminal transition should have empty legal mask, got {mask.sum().item()} True bits"
+        else:
+            assert mask.any(), \
+                "non-terminal transition has empty legal mask — phantom-action regression"
+    assert saw_terminal, "expected at least one terminal transition in replay"

--- a/train_backend.py
+++ b/train_backend.py
@@ -55,6 +55,7 @@ def _make_learner_player(
         reward_mode=n.reward_mode,
         shaping_weight=n.shaping_weight,
         win_bonus=n.win_bonus,
+        trick_diff_weight=getattr(n, "trick_diff_weight", 0.10),
     )
 
 
@@ -188,6 +189,8 @@ class TrainBackend:
             # buffer below batch_size). The frontend treats NaN as a gap.
             "q_loss": [],
             "sl_loss": [],
+            "q_target_abs": [],
+            "q_advantage": [],
             "q_grad_steps": [],
             "sl_grad_steps": [],
         }
@@ -374,6 +377,8 @@ class TrainBackend:
                     losses = self.shared_learner.snapshot_losses()
                     self.metrics["q_loss"].append(losses["q_loss"])
                     self.metrics["sl_loss"].append(losses["sl_loss"])
+                    self.metrics["q_target_abs"].append(losses.get("q_target_abs", float("nan")))
+                    self.metrics["q_advantage"].append(losses.get("q_advantage", float("nan")))
                     self.metrics["q_grad_steps"].append(losses["q_steps"])
                     self.metrics["sl_grad_steps"].append(losses["sl_steps"])
                 self._time_post_game += time.perf_counter() - t1


### PR DESCRIPTION
Double-DQN target was argmaxing over all 52 actions including illegal ones. Phantom-action Q-values drifted unboundedly and poisoned every legitimate state via bootstrapping, locking the policy below random. Mask next-Q with the player's hand before argmax in both Shared and legacy _optimize_q paths.

Also: trick_diff_weight 0.02->0.10 and q_lr 3e-4->5e-4 to restore signal strength now that masking caps |Q*|; gamma 0.99->0.97 and tau 0.005->0.002 as belt-and-braces; Q-advantage telemetry + dashboard chart series; regression tests in test_action_masking.py.